### PR TITLE
Add option to suppress success notifications

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -16,6 +16,14 @@ export default {
   dockerView: null,
   bottomPanel: null,
   subscriptions: null,
+  config: {
+    supressNotifications: {
+      title: 'Supress notifications',
+      description: 'This supresses "verbose" notifications when commands are successfully executed',
+      type: 'boolean',
+      default: false
+    }
+  },
 
   activate(state) {
     this.dockerView = document.createElement('div');
@@ -54,7 +62,12 @@ export default {
     return {
     };
   },
-
+  pushSuccessVerboseNotification(...args) {
+    if(atom.config.get('docker.supressNotifications')) {
+      return;
+    }
+    atom.notifications.addSuccess(...args);
+  },
   selectComposeFile() {
     return new Promise((resolve, reject) => {
       let grammarName = atom.workspace.getActiveTextEditor().getGrammar().name;
@@ -213,7 +226,7 @@ export default {
     } else {
       this.execComposeCommand(action, serviceNames, action == "ps")
       .then((stdout) => {
-        atom.notifications.addSuccess(`${action} ${serviceNames && serviceNames.length > 0 ? serviceNames.join(' ') : ""}`, {});
+        this.pushSuccessVerboseNotification(`${action} ${serviceNames && serviceNames.length > 0 ? serviceNames.join(' ') : ""}`, {});
         if (action == "ps") {
           this.handlePSOutput(stdout);
         }


### PR DESCRIPTION
Hi @alanzanattadev! First of all, thanks for your effort in building this package. Controlling and viewing docker status and logs from Atom is really good.

After using it for a couple of days, I noticed the success notifications were bothering me quite a bit, and even distracting me, and that's what this pull request is about. It adds a new setting parameter (that comes disabled as default), that suppresses those success notifications, while keeping all warnings and possible failures.

<img width="885" alt="screen shot 2016-05-21 at 2 06 18 pm" src="https://cloud.githubusercontent.com/assets/77198/15449768/ae7e5960-1f5d-11e6-9f4f-5a5a3f95cace.png">