### PR TITLE
Update log style

### DIFF
--- a/styles/docker.less
+++ b/styles/docker.less
@@ -150,7 +150,8 @@
   }
 
   .service-logs {
-    background-color: @background-color-highlight;
+    background-color: inherit;
+    font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
     font-size: @font-size;
     flex-shrink: 1;
   }


### PR DESCRIPTION
This updates the log panel to respect the panel background, instead of using the highlight color, and also applies an monospaced font family on it, more suitable for viewing logs and application output.

## Before
<img width="966" alt="screen shot 2016-05-21 at 2 16 56 pm" src="https://cloud.githubusercontent.com/assets/77198/15449817/dd2ee940-1f5e-11e6-86ca-b0014ffd627b.png">

## After
<img width="962" alt="screen shot 2016-05-21 at 2 17 45 pm" src="https://cloud.githubusercontent.com/assets/77198/15449820/e7c84a18-1f5e-11e6-95db-bd742d3cfd66.png">
