### PR TITLE
Add tooltips to buttons

### DIFF
--- a/lib/components/ServiceControls.js
+++ b/lib/components/ServiceControls.js
@@ -36,15 +36,15 @@ export default React.createClass({
         }
         {
           this.props.onPSClick ?
-            (<button className="compose-control icon icon-docker-ps" type="button" onClick={this.props.onPSClick}></button>)
+            (<button className="compose-control icon icon-docker-ps" type="button" title="Refresh containers status" onClick={this.props.onPSClick}></button>)
           :
           undefined
         }
-        <button className="compose-control icon icon-docker-up" type="button" onClick={this.props.onUpClick}></button>
-        <button className="compose-control icon icon-docker-build" type="button" onClick={this.props.onBuildClick}></button>
-        <button className="compose-control icon icon-docker-restart" type="button" onClick={this.props.onRestartClick}></button>
-        <button className="compose-control icon icon-docker-stop" type="button" onClick={this.props.onStopClick}></button>
-        <button className="compose-control icon icon-docker-rm" type="button" onClick={this.props.onRmClick}></button>
+        <button className="compose-control icon icon-docker-up" type="button" title="Starts the container" onClick={this.props.onUpClick}></button>
+        <button className="compose-control icon icon-docker-build" type="button" title="Builds the container image" onClick={this.props.onBuildClick}></button>
+        <button className="compose-control icon icon-docker-restart" type="button" title="Restarts the container" onClick={this.props.onRestartClick}></button>
+        <button className="compose-control icon icon-docker-stop" type="button" title="Stops the container" onClick={this.props.onStopClick}></button>
+        <button className="compose-control icon icon-docker-rm" type="button" title="Removes the container" onClick={this.props.onRmClick}></button>
         <input type="checkbox" className="compose-control" checked={this.props.selected} onChange={(event) => {this.props.onFilterChange(event.target.checked)}}/>
       </div>
     );


### PR DESCRIPTION
This adds tooltips to each interface button, in order to give a tip of what they mean, when hovering them.

<img width="483" alt="screen shot 2016-05-21 at 2 20 41 pm" src="https://cloud.githubusercontent.com/assets/77198/15449840/43bdcc12-1f5f-11e6-9ad5-f730ab7e8723.png">
